### PR TITLE
Fix script error preventing note persistence

### DIFF
--- a/Notepad/script.js
+++ b/Notepad/script.js
@@ -124,11 +124,4 @@ function loadFromLocalStorage() {
   });
 }
 
-let actions = document.createElement("div");
-actions.className = "actions";
-actions.appendChild(newNoteC);
-actions.appendChild(newNoteD);
-newNote.appendChild(actions);
-
-
 loadFromLocalStorage();


### PR DESCRIPTION
## Summary
- remove leftover initialization at bottom of script
- keep `loadFromLocalStorage()` call

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686524d102c883339b8e88959839a6e6